### PR TITLE
fix crash on encountering broken symlinks

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,3 @@
 (library
  (name omen)
- (libraries str notty notty.unix unix))
+ (libraries str notty notty.unix unix ansi))

--- a/lib/main_loop.ml
+++ b/lib/main_loop.ml
@@ -16,7 +16,7 @@ let show_help ctx =
       ("g", "Go to first entry in directory");
       ("G", "Go to last entry in directory");
       ("", "");
-      ("s", "Select this item");
+      ("Space, s", "Select this item");
       ("a", "Select all items in current directory");
       ("u", "Unselect all selected items");
       ("", "");
@@ -54,6 +54,7 @@ let get_action event =
   | `Key (`ASCII 'r', _) -> Rename
   | `Key (`ASCII 'n', _) -> CreateNew
   | `Key (`ASCII 's', _) -> Select
+  | `Key (`ASCII ' ', _) -> Select
   | `Key (`ASCII 'a', _) -> SelectAll
   | `Key (`ASCII 'u', _) -> UnselectAll
   | `Key (`ASCII '/', _) -> Filter

--- a/lib/term_render.ml
+++ b/lib/term_render.ml
@@ -29,7 +29,7 @@ let file_info_img file_info selected_i filter_text =
   | Some (classification, selected_file) ->
       let tot_num = List.length file_info in
 
-      let stats = Unix.stat selected_file in
+      let stats = Unix.lstat selected_file in
       let k = 1024 in
       let m = k * k in
       let g = m * k in
@@ -116,7 +116,7 @@ let preview_img (classification, selected_file) term_height =
           List.rev lines
     in
 
-    if is_binary then
+    if is_binary || classification = Symlink then
       let output = cmd_output_line "file" [ "-b"; selected_file ] in
       I.(
         string A.(fg lightgreen) "--- File details ---"

--- a/lib/term_render.ml
+++ b/lib/term_render.ml
@@ -122,10 +122,14 @@ let preview_img (classification, selected_file) term_height =
         string A.(fg lightgreen) "--- File details ---"
         <-> string A.empty output)
     else
-      let chan = open_in selected_file in
-      let lines = read_lines chan [] term_height in
-      let line_imgs = List.map (I.string A.empty) lines in
-      I.vcat line_imgs
+      try
+        let chan = open_in selected_file in
+        let lines = read_lines chan [] term_height in
+        let line_imgs = List.map (I.string A.empty) lines in
+        I.vcat line_imgs
+      with Sys_error _ ->
+        I.(string A.(fg lightgreen) "--- File details ---"
+          <-> string A.empty "Permission Denied" )
 
 let main_content_img file_info size
     { selected_i; win_start_i; selected_files; _ } =

--- a/lib/term_render.ml
+++ b/lib/term_render.ml
@@ -125,8 +125,6 @@ let preview_img (classification, selected_file) term_height =
         <-> string A.empty output)
     else
       try
-        let chan = open_in selected_file in
-        let lines = read_lines chan [] term_height in
         let tab_replacement = List.init spaces_in_tab (fun _ -> ' ') in
         let filter_tabs (line : string) : string =
           let chars = String.to_seq line |> List.of_seq in
@@ -137,8 +135,12 @@ let preview_img (classification, selected_file) term_height =
             |  [] -> accum
           in aux [] chars |> List.rev |> List.to_seq |> String.of_seq
         in
-        let lines' = List.map filter_tabs lines in
-        let line_imgs = List.map (I.string A.empty) lines' in
+        let chan = open_in selected_file in
+        let lines = read_lines chan [] term_height
+          |> List.map filter_tabs
+          |> List.map Ansi.strip
+        in
+        let line_imgs = List.map (I.string A.empty) lines in
         I.vcat line_imgs
       with Sys_error _ ->
         I.(string A.(fg lightgreen) "--- File details ---"

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -42,7 +42,7 @@ let read_dir dir =
     List.map
       (fun name ->
         let path = Filename.concat dir name in
-        let stats = Unix.stat path in
+        let stats = Unix.lstat path in
         let classification =
           match stats.st_kind with
           | Unix.S_LNK -> Symlink

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -1,5 +1,20 @@
 open Types
 
+let empty_stats : Unix.stats =        
+{ st_dev = 0;
+  st_ino = 0;
+  st_kind = S_REG;
+  st_perm = 0;
+  st_nlink = 0;
+  st_uid = 0;
+  st_gid = 0;
+  st_rdev = 0;
+  st_size = 0;
+  st_atime = 0.0;
+  st_mtime = 0.0;
+  st_ctime = 0.0;
+  }
+
 let perm_str perm classification =
   let usr_perm = (perm land 0o700) lsr 6 in
   let grp_perm = (perm land 0o070) lsr 3 in
@@ -31,7 +46,9 @@ let cmd_output_line cmd args =
 let read_dir dir =
   let cwd = Sys.getcwd () in
   let dir = Filename.concat cwd dir in
-  let contents = Array.to_list (Sys.readdir dir) in
+  let contents = ( try (Sys.readdir dir) with Sys_error _ ->
+    [|"Permission Denied"|] ) |> Array.to_list
+  in
   let contents =
     List.sort
       (fun x y ->
@@ -42,7 +59,9 @@ let read_dir dir =
     List.map
       (fun name ->
         let path = Filename.concat dir name in
-        let stats = Unix.lstat path in
+        let stats = try ( Unix.lstat path ) with Unix.Unix_error _ ->
+          empty_stats
+        in
         let classification =
           match stats.st_kind with
           | Unix.S_LNK -> Symlink


### PR DESCRIPTION
replaced all Unix.stat calls with Unix.lstat since it deals with broken symlinks and added additiontal condition when preparing file previews to treat symlinks as binary files instead of trying to read from them